### PR TITLE
Added ARIA attributes to emoji and moved emoji markup to a Jekyll include

### DIFF
--- a/_includes/emoji-icon.html
+++ b/_includes/emoji-icon.html
@@ -1,0 +1,1 @@
+<i class="em em-{{ emoji.name }}" aria-role="presentation" aria-label="{{ emoji.description }}"></i>

--- a/_includes/emoji.html
+++ b/_includes/emoji.html
@@ -1,0 +1,5 @@
+{% capture alternative_names %}
+{% if emoji.alt_names.size > 1 %}{{ emoji.alt_names | join:',' }}{% else %}{{ emoji.name }}
+{% endif %}
+{% endcapture %}
+{% include emoji-icon.html emoji=emoji %} em-<span class="name" data-alternative-names="{{ alternative_names | strip }}">{{ emoji.name }}</span>

--- a/index.html
+++ b/index.html
@@ -23,9 +23,14 @@
     <p>
       Want to include emoji in your HTML? Just include the (minified) stylesheet below, then add <code>&lt;i&gt;</code> tags to insert emoji. That's it!<br>
       &#x2708; <b>Click the emoji code and it will be copied to your clipboard.</b>
-      <pre><code>&lt;link href="https://afeld.github.io/emoji-css/emoji.css" rel="stylesheet"&gt;
+    </p>
+{% highlight html %}
+<link href="https://afeld.github.io/emoji-css/emoji.css" rel="stylesheet">
 
-&lt;i class="em em-some-emoji"&gt;&lt;/i&gt;</code></pre>
+{% assign emoji=site.data.emoji[104] %}{% include emoji-icon.html %}
+
+{% endhighlight %}
+    <p>
       By default, the emoji will be served as PNGs. To use SVG instead, use the <code>em-svg</code> class instead of <code>em</code>. This will scale better, but has larger file size.
     </p>
     <ul class="emojis">

--- a/index.html
+++ b/index.html
@@ -29,9 +29,10 @@
       By default, the emoji will be served as PNGs. To use SVG instead, use the <code>em-svg</code> class instead of <code>em</code>. This will scale better, but has larger file size.
     </p>
     <ul class="emojis">
-      {% for emo in site.data.emoji %}
-        <li class="emoji" data-clipboard-text="&lt;i class=&quot;em em-{{ emo.name }}&quot;&gt;&lt;/i&gt;">
-          <i class="em em-{{ emo.name }}"></i> em-<span class="name" data-alternative-names="{{ emo.description | split: '#' | concat: emo.alt_names | join: ',' }}">{{ emo.name }}</span>
+      {% for emoji in site.data.emoji %}
+        {% capture clipboard_text %}{% include emoji-icon.html %}{% endcapture %}
+        <li class="emoji" data-clipboard-text="{{ clipboard_text | replace:'"','&quot;' | replace:'<','&lt;' | replace:'>','&gt;' }}">
+          {% include emoji.html %}
         </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
Hello, I've added ARIA attributes and moved some things around to fix #33.

I've added the `aria-role` and `aria-label` attributes to the `<i class="em"></i>` element.

As part of this change I moved the emoji markup out to a Jekyll include so that it can be re-used -- for example the `emoji-icon.html` is used in three places now. 

I also adjusted how the `data-alternative-names` attribute is generated, so that it falls back to just the `emoji-name` if there are no alternatives specified.

With the change to use the `{% highlight %}` Jekyll tag, you can now apply some syntax highlighting styles to the code block if you feel like it.

If you want to use a different emoji in the example, you just need to change the index from `104` to something else:

    {% assign emoji=site.data.emoji[104] %}{% include emoji-icon.html %}

